### PR TITLE
feat: add prepare-deployment script to quickly prepare deployments for base wearables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,39 @@ npm install
 }
 ```
 
+## Prepare Deployment to Content Server
+
+> ℹ️ This script generates a deployment command for base wearables that have been updated in a specific commit.
+
+> **Pending:** Extend support for deploying any updated wearable (not limited to base-wearables) across multiple commits.
+
+### How to Use
+
+Run `npm run prepare-deploy <COMMIT_HASH>` to generate the command needed to deploy the base wearables updated in that specific commit.
+
+The generated deploy command will contain all the wearables to be deployed:
+
+
+`npm run deploy -- --identityFilePath <identity-file> --target <node-to-deploy> --id <first-wearable-to-deploy> --id <N-wearable-to-deploy>`
+
+- `--identityFilePath`: Replace with the file path of the identity key (e.g: ~/keys/address).
+- `--target`: Replace with the target node where the wearables will be deployed (e.g: https://peer-testing-2.decentraland.org).
+
+### Examples
+
+#### Deploy Base Wearables Updated in a Specific Commit
+
+```
+npm run prepare-deploy 679911429fb0415fb77dfdbc91d011c187444faa
+```
+
+This command will generate: `npm run deploy -- --identityFilePath <identity-file> --target <node-to-deploy> --id "dcl://base-avatars/relaxed_hair"`, as the commit only updated the `relaxed_hair` wearable.
+
 ## Deploy to Content Server
 
-ℹ️ This script will generate a new entity every time the script is run
+> ℹ️ This script will generate a new entity every time the script is run
 
-⚠️ If you are deploying new base wearables please be sure that its urn is in https://github.com/decentraland/catalyst/blob/master/lambdas/src/apis/collections/off-chain/base-avatars.ts
+> ⚠️ If you are deploying new base wearables please be sure that its urn is in https://github.com/decentraland/catalyst/blob/master/lambdas/src/apis/collections/off-chain/base-avatars.ts
 
 ### How to Use
 

--- a/assets/base-avatars/upper_body/Ubody_SkaterColoredLongSleeve/asset.json
+++ b/assets/base-avatars/upper_body/Ubody_SkaterColoredLongSleeve/asset.json
@@ -12,11 +12,11 @@
   "main": [
     {
       "type": "dcl://base-avatars/BaseFemale",
-      "model": "F_uBody_skatercoloredlongsleeve.glb"
+      "model": "F_uBody_SkaterColoredLongSleeve.glb"
     },
     {
       "type": "dcl://base-avatars/BaseMale",
-      "model": "M_uBody_skatercoloredlongsleeve.glb"
+      "model": "M_uBody_SkaterColoredLongSleeve.glb"
     }
   ]
 }

--- a/assets/base-avatars/upper_body/Ubody_SkaterQuadLongSleeve/asset.json
+++ b/assets/base-avatars/upper_body/Ubody_SkaterQuadLongSleeve/asset.json
@@ -12,11 +12,11 @@
   "main": [
     {
       "type": "dcl://base-avatars/BaseFemale",
-      "model": "F_uBody_skaterquadlongsleeve.glb"
+      "model": "F_uBody_SkaterQuadLongSleeve.glb"
     },
     {
       "type": "dcl://base-avatars/BaseMale",
-      "model": "M_uBody_skaterquadlongsleeve.glb"
+      "model": "M_uBody_SkaterQuadLongSleeve.glb"
     }
   ]
 }

--- a/assets/base-avatars/upper_body/Ubody_SkaterTrianglesLongSleeve/asset.json
+++ b/assets/base-avatars/upper_body/Ubody_SkaterTrianglesLongSleeve/asset.json
@@ -12,11 +12,11 @@
   "main": [
     {
       "type": "dcl://base-avatars/BaseFemale",
-      "model": "F_uBody_skatertriangleslongsleeve.glb"
+      "model": "F_uBody_SkaterTrianglesLongSleeve.glb"
     },
     {
       "type": "dcl://base-avatars/BaseMale",
-      "model": "M_uBody_skatertriangleslongsleeve.glb"
+      "model": "M_uBody_SkaterTrianglesLongSleeve.glb"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.2.0",
   "description": "Decentraland basic set of avatar assets",
   "scripts": {
-    "deploy": "npx ts-node -T src/index.ts"
+    "deploy": "npx ts-node -T src/index.ts",
+    "prepare-deploy": "npx ts-node -T src/scripts/prepare-deployment.ts"
   },
   "repository": {
     "type": "git",

--- a/src/migration/deploy.ts
+++ b/src/migration/deploy.ts
@@ -114,8 +114,8 @@ async function buildMetadata(wearable: Wearable): Promise<WearableMetadata> {
 
   // Prepare new data property
   const data = {
-    replaces,
-    hides,
+    replaces: replaces || [],
+    hides: hides || [],
     tags,
     category,
     representations: representations.map((representation) => ({

--- a/src/scripts/prepare-deployment.ts
+++ b/src/scripts/prepare-deployment.ts
@@ -1,0 +1,55 @@
+import { execSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+// Get updated directories based on a commit hash
+function getUpdatedDirectories(commitHash: string): string[] {
+  const gitDiffCommand = `git diff --name-only ${commitHash}^ ${commitHash}`
+  const diffOutput = execSync(gitDiffCommand).toString().trim()
+  const fileNames = diffOutput.split('\n')
+  const directories = new Set<string>()
+
+  for (const fileName of fileNames) {
+    const directory = fileName.substring(0, fileName.lastIndexOf('/'))
+    directories.add(directory)
+  }
+
+  return Array.from(directories)
+}
+
+// Check if a directory path includes '/base-avatars/'
+function isBaseAvatar(directoryPath: string): boolean {
+  return directoryPath.includes('/base-avatars/')
+}
+
+// Check if a directory contains an 'asset.json' file
+function containsAssetFile(directoryPath: string): boolean {
+  const assetJsonPath = path.join(directoryPath, 'asset.json')
+  return fs.existsSync(assetJsonPath)
+}
+
+// Get asset name from a file path
+function getAssetName(filepath: string) {
+  const data = fs.readFileSync(filepath)
+  const asset = JSON.parse(data as any)
+  return asset.name
+}
+
+// Prepare the deployment command
+function prepareDeploymentCommand(args: string[]) {
+  const commitHash = args[2]
+  const rootDirectory = path.resolve(__dirname, '../..')
+
+  const updatedDirectories = getUpdatedDirectories(commitHash)
+    .map((updatedDirectory) => path.join(rootDirectory, updatedDirectory))
+    .filter((fullUpdatedDirectory) => containsAssetFile(fullUpdatedDirectory) && isBaseAvatar(fullUpdatedDirectory))
+
+  const wearablesNamesToDeploy = updatedDirectories.map((updatedDirectory) => getAssetName(path.join(updatedDirectory, 'asset.json')))
+  console.log(`Preparing deployment for ${wearablesNamesToDeploy.length} base wearables`)
+
+  const wearablesAsArguments = wearablesNamesToDeploy.map((wearableName) => `--id "dcl://base-avatars/${wearableName}"`)
+
+  console.log('Command to deploy wearables:\n' + `npm run deploy -- --identityFilePath <identity-file> --target <node-to-deploy> ${wearablesAsArguments.join(' ')}`)
+}
+
+prepareDeploymentCommand(process.argv)


### PR DESCRIPTION
This PR:
- Adds a script to prepare deployments of base-wearables so the manual work is reduced
- Fix many base wearables wrongly configured
- Avoid failing when `replaces` and `overrides` properties are not present
- Updates `README.md` to explain how to use `prepare-deploy` script