### PR TITLE
fix: prepare-deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ The generated deploy command will contain all the wearables to be deployed:
 npm run prepare-deploy 679911429fb0415fb77dfdbc91d011c187444faa
 ```
 
-This command will generate: `npm run deploy -- --identityFilePath <identity-file> --target <node-to-deploy> --id "dcl://base-avatars/relaxed_hair"`, as the commit only updated the `relaxed_hair` wearable.
+This command will generate: `npm run deploy -- --identityFilePath <identity-file> --target <node-to-deploy> --id dcl://base-avatars/relaxed_hair`, as the commit only updated the `relaxed_hair` wearable.
+
+**Please note that the parameters should not be enclosed within double quotes (").**
 
 ## Deploy to Content Server
 

--- a/src/scripts/prepare-deployment.ts
+++ b/src/scripts/prepare-deployment.ts
@@ -47,7 +47,7 @@ function prepareDeploymentCommand(args: string[]) {
   const wearablesNamesToDeploy = updatedDirectories.map((updatedDirectory) => getAssetName(path.join(updatedDirectory, 'asset.json')))
   console.log(`Preparing deployment for ${wearablesNamesToDeploy.length} base wearables`)
 
-  const wearablesAsArguments = wearablesNamesToDeploy.map((wearableName) => `--id "dcl://base-avatars/${wearableName}"`)
+  const wearablesAsArguments = wearablesNamesToDeploy.map((wearableName) => `--id dcl://base-avatars/${wearableName}`)
 
   console.log('Command to deploy wearables:\n' + `npm run deploy -- --identityFilePath <identity-file> --target <node-to-deploy> ${wearablesAsArguments.join(' ')}`)
 }


### PR DESCRIPTION
Fix `prepare-deploy` script to return the parameters without quotes and update REAMDE to note this.