### PR TITLE
chore: add @pentreathm to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # @decentraland/platform owns any files in the src
 # directory at the root of the repository and any of its
 # subdirectories.
-/src/ @decentraland/platform
+/src/ @decentraland/platform @pentreathm


### PR DESCRIPTION
Adds @pentreathm as a code owner for the src directory.